### PR TITLE
Fix README image line

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![image](https://github.com/andmartins7/chat-db/assets/128826621/d979d3a7-b79b-477b-94b7-7c99694e3c2c)
 
-
 # Descrição do Projeto
 Este projeto é uma aplicação Python que demonstra a integração de várias tecnologias, incluindo AWS Athena, Azure OpenAI, e o uso de um agente SQL para processar consultas em linguagem natural e convertê-las em SQL. A aplicação utiliza variáveis de ambiente para gerenciar informações sensíveis e oferece uma interface para executar consultas em linguagem natural que são traduzidas em consultas SQL.
 


### PR DESCRIPTION
## Summary
- remove an extra blank line so the image link in README.md sits on a single line

## Testing
- `python3 -m py_compile app.py`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684083e85cb08325ae4d3eec704b1ebc