### PR TITLE
Add connection string helper and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,71 +1,81 @@
 import os
-from dotenv import load_dotenv
-from sqlalchemy import create_engine
-from langchain.utilities import SQLDatabase
-from langchain.agents import create_sql_agent
-from langchain.agents.agent_toolkits import SQLDatabaseToolkit
-from langchain.agents.agent_types import AgentType
-from langchain.chat_models import AzureChatOpenAI
 
-# Carrega as variáveis de ambiente do arquivo .env
-load_dotenv()
 
-# Verifica se as variáveis de ambiente essenciais estão definidas
-required_vars = [
-    "AZURE_OPENAI_API_KEY",
-    "AZURE_OPENAI_ENDPOINT",
-    "AZURE_DEPLOYMENT_NAME",
-    "AWS_REGION",
-    "S3_LOCATION",
-    "AWS_USER",
-    "AWS_DB_PASSWORD",
-]
-missing = [var for var in required_vars if not os.getenv(var)]
-if missing:
-    raise EnvironmentError(
-        "Variáveis de ambiente ausentes: " + ", ".join(missing)
+def build_athena_uri() -> str:
+    """Return the Athena connection URI built from environment variables."""
+    region = os.environ.get("AWS_REGION")
+    s3_location = os.environ.get("S3_LOCATION")
+    user = os.environ.get("AWS_USER")
+    password = os.environ.get("AWS_DB_PASSWORD")
+    return (
+        f"awsathena+rest://{user}:{password}@athena.{region}.amazonaws.com:443/"
+        "caminho_para_o_banco_de_dados_especifico_no_Athena_que_você_"
+        "deseja_acessar"
+        f"?s3_staging_dir={s3_location}/athenaresults/&work_group=grupo_de_trabalho"
     )
 
-# Configuração do Azure OpenAI
-os.environ["AZURE_OPENAI_API_KEY"] = os.getenv('AZURE_OPENAI_API_KEY')
-os.environ["AZURE_OPENAI_ENDPOINT"] = os.getenv('AZURE_OPENAI_ENDPOINT')
 
-# Acessar as variáveis de ambiente
-region = os.environ.get('AWS_REGION')
-s3_location = os.environ.get('S3_LOCATION')
-user = os.environ.get('AWS_USER')
-password = os.environ.get('AWS_DB_PASSWORD')
-# openai_api_key = os.environ.get('OPENAI_API_KEY')
-athena_db_uri = (
-    f"awsathena+rest://{user}:{password}@athena.{region}.amazonaws.com:443/"
-    "caminho_para_o_banco_de_dados_especifico_no_Athena_que_você_"
-    "deseja_acessar"
-    f"?s3_staging_dir={s3_location}/athenaresults/"
-    f"&work_group=grupo_de_trabalho"
-)
+def main() -> None:
+    from dotenv import load_dotenv
+    from sqlalchemy import create_engine
+    from langchain.utilities import SQLDatabase
+    from langchain.agents import create_sql_agent
+    from langchain.agents.agent_toolkits import SQLDatabaseToolkit
+    from langchain.agents.agent_types import AgentType
+    from langchain.chat_models import AzureChatOpenAI
 
-# Conexão com o Athena
-athena_engine = create_engine(athena_db_uri, echo=True)
-athena_db_connection = SQLDatabase(athena_engine)
+    # Carrega as variáveis de ambiente do arquivo .env
+    load_dotenv()
 
-# Inicialização do modelo de linguagem Azure OpenAI
-llm = AzureChatOpenAI(
-    azure_deployment=os.getenv('AZURE_DEPLOYMENT_NAME'),
-    openai_api_version="2023-05-15"
-)
+    # Verifica se as variáveis de ambiente essenciais estão definidas
+    required_vars = [
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_DEPLOYMENT_NAME",
+        "AWS_REGION",
+        "S3_LOCATION",
+        "AWS_USER",
+        "AWS_DB_PASSWORD",
+    ]
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(
+            "Variáveis de ambiente ausentes: " + ", ".join(missing)
+        )
 
-# Inicialização do toolkit
-toolkit = SQLDatabaseToolkit(db=athena_db_connection, llm=llm)
+    # Configuração do Azure OpenAI
+    os.environ["AZURE_OPENAI_API_KEY"] = os.getenv("AZURE_OPENAI_API_KEY")
+    os.environ["AZURE_OPENAI_ENDPOINT"] = os.getenv("AZURE_OPENAI_ENDPOINT")
 
-# Criação do agente SQL
-agent_executor = create_sql_agent(
-    llm=llm,
-    toolkit=toolkit,
-    verbose=True,
-    agent_type=AgentType.ZERO_SHOT_REACT_DESCRIPTION  # Use OPENAI_FUNCS
-)
+    # Cria URI de conexão
+    athena_db_uri = build_athena_uri()
 
-# Processar consulta em linguagem natural e gerar SQL
-natural_language_query = input("Digite sua consulta em linguagem natural: ")
-sql_query = agent_executor.run(natural_language_query)
-print(f"Sua consulta SQL é: {sql_query}")
+    # Conexão com o Athena
+    athena_engine = create_engine(athena_db_uri, echo=True)
+    athena_db_connection = SQLDatabase(athena_engine)
+
+    # Inicialização do modelo de linguagem Azure OpenAI
+    llm = AzureChatOpenAI(
+        azure_deployment=os.getenv("AZURE_DEPLOYMENT_NAME"),
+        openai_api_version="2023-05-15",
+    )
+
+    # Inicialização do toolkit
+    toolkit = SQLDatabaseToolkit(db=athena_db_connection, llm=llm)
+
+    # Criação do agente SQL
+    agent_executor = create_sql_agent(
+        llm=llm,
+        toolkit=toolkit,
+        verbose=True,
+        agent_type=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+    )
+
+    # Processar consulta em linguagem natural e gerar SQL
+    natural_language_query = input("Digite sua consulta em linguagem natural: ")
+    sql_query = agent_executor.run(natural_language_query)
+    print(f"Sua consulta SQL é: {sql_query}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure the project root is on the path so app can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,17 @@
+import os
+from app import build_athena_uri
+
+
+def test_build_athena_uri(monkeypatch):
+    monkeypatch.setenv("AWS_USER", "dummy_user")
+    monkeypatch.setenv("AWS_DB_PASSWORD", "dummy_pass")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("S3_LOCATION", "s3://bucket")
+
+    expected = (
+        "awsathena+rest://dummy_user:dummy_pass@athena.us-east-1.amazonaws.com:443/"
+        "caminho_para_o_banco_de_dados_especifico_no_Athena_que_você_"
+        "deseja_acessar?s3_staging_dir=s3://bucket/athenaresults/&work_group=grupo_de_trabalho"
+    )
+
+    assert build_athena_uri() == expected


### PR DESCRIPTION
## Summary
- refactor `app.py` to provide `build_athena_uri` helper and move heavy imports under `main`
- add unit test for `build_athena_uri`
- ensure project root is on `sys.path` for tests via `conftest.py`
- configure pytest via `pytest.ini`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684083ecba0c832590eabbb1e010b520